### PR TITLE
Corrected Strict errors on Service/Abstract

### DIFF
--- a/Cpanel/PublicAPI.php
+++ b/Cpanel/PublicAPI.php
@@ -76,7 +76,7 @@ class Cpanel_PublicAPI extends Cpanel_Core_Object
      * The class is a Singleton.  The constructor, however is public due to
      * inheritance from Cpanel_Core_Object.
      * 
-     * @param arrays $optsArray Option configuration data
+     * @param array $optsArray Option configuration data
      * 
      * @return Cpanel_PublicAPI  
      * @throws Exception If      instantiated directly. {@link getInstance()}

--- a/Cpanel/Service/Abstract.php
+++ b/Cpanel/Service/Abstract.php
@@ -515,7 +515,8 @@ abstract class Cpanel_Service_Abstract extends Cpanel_Core_Object
             );
         }
         ksort($arr);
-        $fkey = array_shift(array_keys($arr));
+        $keys=array_keys($arr);
+        $fkey = array_shift($keys);
         if (is_int($fkey)) {
             return self::API1ARGS;
         }


### PR DESCRIPTION
I have corrected an Strict Error On Cpanel/Service/Abstract.php, line 518

The error was: Strict Error: Only variables should be passed by reference in ... Cpanel/Service/Abstract.php

Also edited a PHPdoc that was erroneous
